### PR TITLE
Expose the VaultBuilders.runtimeConfigBuilder method

### DIFF
--- a/src/main/java/com/github/golovnin/embedded/vault/VaultBuilders.java
+++ b/src/main/java/com/github/golovnin/embedded/vault/VaultBuilders.java
@@ -45,7 +45,7 @@ import de.flapdoodle.embed.process.store.ExtractedArtifactStoreBuilder;
 /**
  * @author Andrej Golovnin
  */
-final class VaultBuilders {
+final public class VaultBuilders {
 
     private VaultBuilders() {
         // NOP
@@ -63,10 +63,14 @@ final class VaultBuilders {
     }
 
     static RuntimeConfigBuilder runtimeConfigBuilder() {
+        return runtimeConfigBuilder(ProcessOutput.getDefaultInstance("default"), new ICommandLinePostProcessor.Noop());
+    }
+
+    public static RuntimeConfigBuilder runtimeConfigBuilder(ProcessOutput processOutput, ICommandLinePostProcessor commandLinePostProcessor) {
         return new RuntimeConfigBuilder()
-            .processOutput(ProcessOutput.getDefaultInstance("vault"))
-            .commandLinePostProcessor(new ICommandLinePostProcessor.Noop())
-            .artifactStore(storeBuilder().build());
+                .processOutput(processOutput)
+                .commandLinePostProcessor(commandLinePostProcessor)
+                .artifactStore(storeBuilder().build());
     }
 
     static ExtractedArtifactStoreBuilder storeBuilder() {


### PR DESCRIPTION
This allows for example a custom Stream Processor to capture the unseal key during tests. 

The current version has both the class and the methods as package level. This PR exposes a new public method, and also changes the class to be public (but keeps it final)